### PR TITLE
 Rename functions for consistency and inclusiveness

### DIFF
--- a/PrivateCloud.DiagnosticInfo/PrivateCloud.DiagnosticInfo.psm1
+++ b/PrivateCloud.DiagnosticInfo/PrivateCloud.DiagnosticInfo.psm1
@@ -1410,7 +1410,7 @@ function Get-PCStorageDiagnosticInfo
 
 		$PerfRaw=Get-Counter -Counter $set.Paths -SampleInterval 1 -MaxSamples $PerfSamples -ErrorAction Ignore -WarningAction Ignore
 		Write-Progress -Activity "Gathering counters" -CurrentOperation "Exporting counters"
-		$PerfRaw | Export-counter -Path ($Path + "GetCounters.blg") -Force -FileFormat “BLG”
+		$PerfRaw | Export-counter -Path ($Path + "GetCounters.blg") -Force -FileFormat Â“BLGÂ”
 		Write-Progress -Activity "Gathering counters" -Completed
 
 		if ($ProcessCounter) {
@@ -2696,3 +2696,4 @@ New-Alias -Name getpcsdi -Value Get-PCStorageDiagnosticInfo -Description "Collec
 New-Alias -Name Test-StorageHealth -Value Get-PCStorageDiagnosticInfo -Description "Collects & reports the Storage Cluster state & diagnostic information"
 
 Export-ModuleMember -Alias * -Function Get-PCStorageDiagnosticInfo,Get-PCStorageReport
+

--- a/PrivateCloud.DiagnosticInfo/PrivateCloud.DiagnosticInfo.psm1
+++ b/PrivateCloud.DiagnosticInfo/PrivateCloud.DiagnosticInfo.psm1
@@ -1406,7 +1406,7 @@ function Get-SddcDiagnosticInfo
 
 		$PerfRaw=Get-Counter -Counter $set.Paths -SampleInterval 1 -MaxSamples $PerfSamples -ErrorAction Ignore -WarningAction Ignore
 		Write-Progress -Activity "Gathering counters" -CurrentOperation "Exporting counters"
-		$PerfRaw | Export-counter -Path ($Path + "GetCounters.blg") -Force -FileFormat BLG
+		$PerfRaw | Export-counter -Path ($Path + "GetCounters.blg") -Force -FileFormat BLG
 		Write-Progress -Activity "Gathering counters" -Completed
 
 		if ($ProcessCounter) {


### PR DESCRIPTION
- Convert to UTF-8 because GitHub forced me to
- Re-brand to Get-SddcDiagnosticInfo (with alias for backward compatibility)
- Add cute but controversial Get-Everything alias
- Eliminate references to "storage clusters" throughout
- Rename some functions that contained PCStorage[...] to simply Storage[...]
- Fix typo by Vinod :-)