### PR TITLE
Added NFS logs to SDDC diagnostic.

### DIFF
--- a/PrivateCloud.DiagnosticInfo/PrivateCloud.DiagnosticInfo.psm1
+++ b/PrivateCloud.DiagnosticInfo/PrivateCloud.DiagnosticInfo.psm1
@@ -292,6 +292,7 @@ $CommonFuncBlock = {
                         'Microsoft-Windows-REFS',
                         'Microsoft-Windows-ResumeKeyFilter',
                         'Microsoft-Windows-SMB',
+			'Microsoft-Windows-ServicesForNFS',
                         'Microsoft-Windows-Storage',
                         'Microsoft-Windows-TCPIP',
                         'Microsoft-Windows-VHDMP',


### PR DESCRIPTION
Bug 24191256: NFS logs needs to be integrated into SDDC diagnostic info.