### PR TITLE
fix issue (new? regression in 5.1?) needing to default a value for th…

### DIFF
--- a/PrivateCloud.DiagnosticInfo/PrivateCloud.DiagnosticInfo.psm1
+++ b/PrivateCloud.DiagnosticInfo/PrivateCloud.DiagnosticInfo.psm1
@@ -4906,7 +4906,7 @@ function Get-StorageLatencyReport
         $CutoffMs = 0,
 
         [datetime]
-        $TimeBase,
+        $TimeBase = 0,
 
         [int]
         $HoursOfEvents = -1
@@ -6032,14 +6032,13 @@ function Show-SddcDiagnosticStorageLatencyReport
 
     # Common header for path validation
 
-    $Path = (gi $Path).FullName
-
     if (-not (Test-Path $Path)) {
         Write-Error "Path is not accessible. Please check and try again: $Path"
         return
     }
 
     # Extract ZIP if neccesary
+    $Path = (gi $Path).FullName
     $Path = Check-ExtractZip $Path
 
     # get the timebase from the capture parameters
@@ -6136,14 +6135,13 @@ function Show-SddcDiagnosticReport
         $Report = [ReportType]::All
     )
 
-    $Path = (gi $Path).FullName
-
     if (-not (Test-Path $Path)) {
         Write-Error "Path is not accessible. Please check and try again: $Path"
         return
     }
 
     # Extract ZIP if neccesary
+    $Path = (gi $Path).FullName
     $Path = Check-ExtractZip $Path
 
     # Produce all reports?


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Give storage latency reporting timebase; passing null value through to report generator causes error
Move get-item after test-path, avoid noisy errors from get-item if path does not exist