### PR TITLE
bump version to 1.1.38 (release)

### DIFF
--- a/PrivateCloud.DiagnosticInfo/PrivateCloud.DiagnosticInfo.psd1
+++ b/PrivateCloud.DiagnosticInfo/PrivateCloud.DiagnosticInfo.psd1
@@ -9,8 +9,8 @@
 # Script module or binary module file associated with this manifest.
 RootModule = 'PrivateCloud.DiagnosticInfo.psm1'
 
-# Version number of this module. Revision < 1000 is pre-release.
-ModuleVersion = '1.1.37.1000'
+# Version number of this module.
+ModuleVersion = '1.1.38'
 
 # ID used to uniquely identify this module
 GUID = '7e0bc824-c371-4936-98e6-b7216ba5f348'

--- a/PrivateCloud.DiagnosticInfo/PrivateCloud.DiagnosticInfo.psm1
+++ b/PrivateCloud.DiagnosticInfo/PrivateCloud.DiagnosticInfo.psm1
@@ -1966,11 +1966,14 @@ function Get-SddcDiagnosticInfo
 
             $JobStatic += start-job -Name CauDebugTrace {
                 try {
+
+                    # SCDT returns a fileinfo object for the saved ZIP on the pipeline; discard (allow errors/warnings to flow as normal)
+
                     if ((Get-Command Save-CauDebugTrace).Parameters.ContainsKey("FeatureUpdateLogs")) {
-                        Save-CauDebugTrace -Cluster $using:AccessNode -FeatureUpdateLogs All -FilePath $using:Path
+                        $null = Save-CauDebugTrace -Cluster $using:AccessNode -FeatureUpdateLogs All -FilePath $using:Path
                     }
                     else {
-                        Save-CauDebugTrace -Cluster $using:AccessNode -FilePath $using:Path
+                        $null = Save-CauDebugTrace -Cluster $using:AccessNode -FilePath $using:Path
                     }
                 }
                 catch { Show-Warning("Unable to get CAU debug trace.  `nError="+$_.Exception.Message) }
@@ -2274,7 +2277,8 @@ function Get-SddcDiagnosticInfo
                             @{ C = 'Get-SmbMultichannelConnection -IncludeNotSelected -SmbInstance SR -CimSession _C_'; F = 'GetSmbMultichannelConnection-SR' },
                             @{ C = 'Get-SmbServerConfiguration -CimSession _C_'; F = $null },
                             @{ C = 'Get-SmbServerNetworkInterface -CimSession _C_'; F = $null },
-                            @{ C = 'Get-StorageFaultDomain -CimSession _A_ -Type StorageScaleUnit |? FriendlyName -eq _N_ | Get-StorageFaultDomain -CimSession _A_'; ; F = $null }
+                            @{ C = 'Get-StorageFaultDomain -CimSession _A_ -Type StorageScaleUnit |? FriendlyName -eq _N_ | Get-StorageFaultDomain -CimSession _A_'; F = $null },
+                            @{ C = 'Get-WindowsFeature -ComputerName _C_'; F = $null }
 
                 # These commands are specific to optional modules, add only if present
                 #   - DcbQos: RoCE environments primarily


### PR DESCRIPTION
add get-windowsfeature to the ps cmdlet capture; allow discovery of optional feature presence/absence like SR
discard pipeline output from Save-CauDebugTrace; fileinfo object for saved ZIP, not needed for validation or presentation directly to Get-SDDC caller