### PR TITLE
Collect the cluster log, health log and netft log sequentially. 

### DIFF
--- a/PrivateCloud.DiagnosticInfo/PrivateCloud.DiagnosticInfo.Tests.ps1
+++ b/PrivateCloud.DiagnosticInfo/PrivateCloud.DiagnosticInfo.Tests.ps1
@@ -1,0 +1,244 @@
+#
+#
+#
+
+Set-StrictMode -Version 3.0
+
+$zpfx = Join-Path $env:TEMP "PesterTest"
+
+function RunGetSddcDiagnosticInfo
+{
+    param(
+        [System.Management.Automation.Runspaces.PSSession]
+        $Session,
+
+        [switch]
+        $ShouldBeSuccessful
+    )
+
+    { Invoke-Command -Session $Session -ErrorVariable script:e { Get-SddcDiagnosticInfo -ZipPrefix $using:zpfx }} | Should Not Throw
+
+    if ($ShouldBeSuccessful)
+    {
+        $script:e | Should BeNullOrEmpty Becaue "the invocation should be successful without errors"
+    }
+    else
+    {
+        $script:e | Should Not BeNullOrEmpty Becaue "the invocation should be unsuccessful"
+    }
+}
+
+function CleanupSddcDiagnosticInfo
+{
+    $z = Get-Item "$zpfx*"
+
+    # $z | Should Not BeNullOrEmpty
+    $z | Remove-Item
+}
+
+<#
+#
+# Preserving rough start at a constrained language mode test. This is not correct as written since clm
+# requires using Device Guard/AppLocker to express constrained language exceptions for signed modules
+# (not limited to but inclusive of system modules) and/or modules located under secured paths. However,
+# it may still lay out useful bones of what it will eventually look like.
+#
+
+Describe "VerifyConstrainedLanguageMode" {
+
+    BeforeAll {
+        $session = New-PSSession -EnableNetworkAccess
+        $script:e = $null
+    }
+
+    It "ParentFullBefore" {
+        $ExecutionContext.SessionState.LanguageMode | Should Be ([System.Management.Automation.PSLanguageMode]::FullLanguage)
+    }
+
+    It "IsFull" {
+        $mode = Invoke-Command -Session $session { $ExecutionContext.SessionState.LanguageMode }
+        $mode | Should Be ([System.Management.Automation.PSLanguageMode]::FullLanguage)
+    }
+
+    It "SetConstrained" {
+        Invoke-Command -Session $session { $ExecutionContext.SessionState.LanguageMode = 'ConstrainedLanguage' }
+        $mode = Invoke-Command -Session $session { $ExecutionContext.SessionState.LanguageMode }
+        $mode | Should Be ([System.Management.Automation.PSLanguageMode]::ConstrainedLanguage)
+    }
+
+    #
+    # do it
+    #
+
+    RunGetSddcDiagnosticInfo $session -ShouldBeSuccessful:$true
+    CleanupSddcDiagnosticInfo
+
+    It "RemainedConstrained" {
+        $mode = Invoke-Command -Session $session { $ExecutionContext.SessionState.LanguageMode }
+        $mode | Should Be ([System.Management.Automation.PSLanguageMode]::ConstrainedLanguage)
+    }
+
+    It "ParentFullAfter" {
+        $ExecutionContext.SessionState.LanguageMode | Should Be ([System.Management.Automation.PSLanguageMode]::FullLanguage)
+    }
+
+    AfterAll {
+        Remove-PSSession $session
+    }
+}
+#>
+
+Describe "VerifyFullLanguageMode" {
+
+    BeforeAll {
+        $session = New-PSSession -EnableNetworkAccess
+        $script:e = $null
+    }
+
+    It "ParentFullBefore" {
+        $ExecutionContext.SessionState.LanguageMode | Should Be ([System.Management.Automation.PSLanguageMode]::FullLanguage)
+    }
+
+    It "IsFull" {
+        $mode = Invoke-Command -Session $session { $ExecutionContext.SessionState.LanguageMode }
+        $mode | Should Be ([System.Management.Automation.PSLanguageMode]::FullLanguage)
+    }
+
+    #
+    # do it
+    #
+
+    RunGetSddcDiagnosticInfo $session -ShouldBeSuccessful:$true
+    CleanupSddcDiagnosticInfo
+
+    It "RemainedFull" {
+        $mode = Invoke-Command -Session $session { $ExecutionContext.SessionState.LanguageMode }
+        $mode | Should Be ([System.Management.Automation.PSLanguageMode]::FullLanguage)
+    }
+
+    It "ParentFullAfter" {
+        $ExecutionContext.SessionState.LanguageMode | Should Be ([System.Management.Automation.PSLanguageMode]::FullLanguage)
+    }
+
+    AfterAll {
+        Remove-PSSession $session
+    }
+}
+
+Describe "TestPrefixFilePath" {
+
+    It "SystemDriveIsDriveLetterColon" {
+        $env:SystemDrive.Length | Should Be 2
+        ($env:SystemDrive[0] -match '[A-Z]') | Should Be $true
+        $env:SystemDrive[1] | Should Be ':'
+    }
+
+    InModuleScope PrivateCloud.DiagnosticInfo {
+
+        Context "InScope" {
+
+            BeforeAll {
+
+                # Get the first lexical existing name in the directory and duplicate the first
+                # character, which guarantees creating a non-existent name. If none exists
+                # use a trivial name.
+                function MakeAvailableName
+                {
+                    param(
+                        [string]
+                        $Path
+                    )
+
+                    $firstName = Get-ChildItem $Path | Select-Object -First 1
+
+                    if ($null -ne $firstName)
+                    {
+                        return $firstName.Name[0] + $firstName.Name
+                    }
+                    else
+                    {
+                        return 'a'
+                    }
+
+                }
+
+                # An available name at the root of the system drive
+                $sysdAvailableName = MakeAvailableName (Join-Path $env:SystemDrive '')
+
+                # An available name in the Windows directory
+                $windAvailableName = MakeAvailableName $env:windir
+
+                # An available name in the current directory
+                $cwdAvailableName = MakeAvailableName '.'
+
+                # Simplify later expressions building UNC paths
+                $cName = $env:COMPUTERNAME
+                $sysDL = $env:SystemDrive[0]
+            }
+
+            It "NoDriveLetter" {
+                Test-PrefixFilePath $env:SystemDrive | Should BeNullOrEmpty Because "this is a bare drive letter with no possible file prefix"
+            }
+
+            It "NoDriveLetterSlash" {
+                Test-PrefixFilePath (Join-Path $env:SystemDrive '') | Should BeNullOrEmpty Because "this is a trailing seperator with no possible file prefix"
+            }
+
+            # at root of drive
+            # c:\somenewname -> yes
+            # c:\somenewname\test -> no
+            It "YesAvailableNameAtRoot" {
+                Test-PrefixFilePath (Join-Path $env:SystemDrive $sysdAvailableName) | Should Not BeNullOrEmpty Because "this is an available name in the system drive and should work"
+            }
+
+            It "NoChildOfAvailableNameAtRoot" {
+                Test-PrefixFilePath (Join-Path (Join-Path $env:SystemDrive $sysdAvailableName) 'test') | Should BeNullOrEmpty Because "this is an available name, and cannot be a directory to put test into"
+            }
+
+            It "NoAvailableNameAtRootAsDirectory" {
+                Test-PrefixFilePath (Join-Path (Join-Path $env:SystemDrive $sysdAvailableName) '') | Should BeNullOrEmpty Because "this is an available name as a directory with no possible file prefix"
+            }
+
+
+            # in child directory, using windir as a convenient must-exist directory
+            # c:\dir\somenewname -> yes
+            # c:\dir\somenewname\test -> no
+            It "YesAvailableNameInChild" {
+                Test-PrefixFilePath (Join-Path $env:windir $windAvailableName) | Should Not BeNullOrEmpty Because "this is an available name in the windows directory and should work"
+            }
+
+            It "NoChildOfAvailableNameInChild" {
+                Test-PrefixFilePath (Join-Path (Join-Path $env:windir $windAvailableName) 'test') | Should BeNullOrEmpty Because "this is an available name, and cannot be a directory to put test into"
+            }
+
+            It "NoAvailableNameInChildAsDirectory" {
+                Test-PrefixFilePath (Join-Path (Join-Path $env:windir $windAvailableName) '') | Should BeNullOrEmpty Because "this is an available name as a directory with no possible file prefix"
+            }
+
+            # unc cases
+            # \\foo -> no
+            # \\foo\bar -> no
+            # \\foo\bar\somenewname -> yes
+            It "NoUNCComputerName" {
+                Test-PrefixFilePath "\\$cName" | Should BeNullOrEmpty Because "this is just a computer name, not a potential filename prefix"
+            }
+
+            It "NoUNCShare" {
+                Test-PrefixFilePath "\\$cName\$sysDL$" | Should BeNullOrEmpty Because "this is just a share, not a potential filename prefix"
+            }
+
+            It "YesUNCShareWithName" {
+                Test-PrefixFilePath "\\$cName\$sysDL$\$sysdAvailableName" | Should Not BeNullOrEmpty Because "this is just a share, not a potential filename prefix"
+            }
+
+            # relative cases using current working directory
+            It "YesCWDAvailableName" {
+                Test-PrefixFilePath "$cwdAvailableName" | Should Not BeNullOrEmpty Because "this is an available name in the cwd"
+            }
+
+            It "NoChildOfCWDAvailableName" {
+                Test-PrefixFilePath (Join-Path $cwdAvailableName "test") | Should BeNullOrEmpty Because "this is an available name, and cannot be a directory to put test into"
+            }
+        }
+    }
+}

--- a/PrivateCloud.DiagnosticInfo/PrivateCloud.DiagnosticInfo.psm1
+++ b/PrivateCloud.DiagnosticInfo/PrivateCloud.DiagnosticInfo.psm1
@@ -2204,10 +2204,7 @@ function Get-SddcDiagnosticInfo
             {
                 $null = Get-ClusterLog -Node $using:ClusterNodes.Name -Destination $using:Path -UseLocalTime -Netft
             }
-        }
-
-        if ($S2DEnabled) {
-            $JobStatic += Start-Job -Name ClusterHealthLogs {
+            if ($S2DEnabled) {
                 $null = Get-ClusterLog -Node $using:ClusterNodes.Name -Destination $using:Path -Health -UseLocalTime
             }
         }

--- a/PrivateCloud.DiagnosticInfo/PrivateCloud.DiagnosticInfo.psm1
+++ b/PrivateCloud.DiagnosticInfo/PrivateCloud.DiagnosticInfo.psm1
@@ -872,7 +872,7 @@ function Invoke-CommonCommand (
 {
     $Sessions = @()
 
-    if ($ClusterNodes.Count -eq 0)
+    if ($null -eq $ClusterNodes -or $ClusterNodes.Count -eq 0)
     {
         $Sessions = New-PSSession -Cn localhost -EnableNetworkAccess -ConfigurationName $SessionConfigurationName
     }
@@ -1881,7 +1881,7 @@ function Get-SddcDiagnosticInfo
         #
 
         $DedupEnabled = $true
-        if ($(Invoke-Command -ComputerName $AccessNode -ConfigurationName $SessionConfigurationName {(-not (Get-Command -Module Deduplication))} )) {
+        if ($null -eq $AccessNode -or $(Invoke-Command -ComputerName $AccessNode -ConfigurationName $SessionConfigurationName {(-not (Get-Command -Module Deduplication))} )) {
             $DedupEnabled = $false
         }
 
@@ -2670,188 +2670,195 @@ function Get-SddcDiagnosticInfo
             }
         }
 
-        #
-        # SMB share health/status
-        #
-
-        Show-Update "SMB Shares"
-
-        try { $SmbShares = Get-SmbShare -CimSession $AccessNode }
-        catch { Show-Error("Unable to get SMB Shares. `nError="+$_.Exception.Message) }
-
-        # XXX only sharepath and health are added in, why are we selecting down to just these four as opposed to add-member?
-        $ShareStatus = $SmbShares |? ContinuouslyAvailable | Select-Object ScopeName, Name, SharePath, Health
-        $Count1 = 0
-        $Total1 = NCount($ShareStatus)
-
-        if ($Total1 -gt 0)
+        if($null -eq $AccessNode)
         {
-            $ShareStatus |% {
-                $Progress = $Count1 / $Total1 * 100
-                $Count1++
-                Write-Progress -Activity "Testing file share access" -PercentComplete $Progress
+            Show-Update "Skipping gathering of cluster storage as no access node was found"
+        }
+        else
+        {
+            #
+            # SMB share health/status
+            #
 
-                if ($ClusterDomain -ne "")
-                {
-                    $_.SharePath = "\\" + $_.ScopeName + "." + $ClusterDomain + "\" + $_.Name
+            Show-Update "SMB Shares"
+            try { $SmbShares = Get-SmbShare -CimSession $AccessNode }
+            catch { Show-Error("Unable to get SMB Shares. `nError="+$_.Exception.Message) }
+
+            # XXX only sharepath and health are added in, why are we selecting down to just these four as opposed to add-member?
+            $ShareStatus = $SmbShares |? ContinuouslyAvailable | Select-Object ScopeName, Name, SharePath, Health
+            $Count1 = 0
+            $Total1 = NCount($ShareStatus)
+
+            if ($Total1 -gt 0)
+            {
+                $ShareStatus |% {
+                    $Progress = $Count1 / $Total1 * 100
+                    $Count1++
+                    Write-Progress -Activity "Testing file share access" -PercentComplete $Progress
+
+                    if ($ClusterDomain -ne "")
+                    {
+                        $_.SharePath = "\\" + $_.ScopeName + "." + $ClusterDomain + "\" + $_.Name
+                    }
+                    else
+                    {
+                        $_.SharePath = "\\" + $_.ScopeName + "\" + $_.Name
+                    }
+                    try { if (Test-Path -Path $_.SharePath  -ErrorAction SilentlyContinue) {
+                                $_.Health = "Accessible"
+                            } else {
+                                $_.Health = "Inaccessible"
+                        }
+                    }
+                    catch { $_.Health = "Accessible: "+$_.Exception.Message }
                 }
-                else
-                {
-                    $_.SharePath = "\\" + $_.ScopeName + "\" + $_.Name
-                }
-                try { if (Test-Path -Path $_.SharePath  -ErrorAction SilentlyContinue) {
-                            $_.Health = "Accessible"
-                        } else {
-                            $_.Health = "Inaccessible"
+                Write-Progress -Activity "Testing file share access" -Completed
+            }
+
+            $ShareStatus | Export-Clixml ($Path + "ShareStatus.XML")
+
+            Show-Update "SMB Share Open Files"
+
+            try {
+                $o = Get-SmbOpenFile -CimSession $AccessNode
+                $o | Export-Clixml ($Path + "GetSmbOpenFile.XML") }
+            catch { Show-Error("Unable to get SMB open files. `nError="+$_.Exception.Message) }
+
+            Show-Update "SMB Share Witness"
+
+            try {
+                $o = Get-SmbWitnessClient -CimSession $AccessNode
+                $o | Export-Clixml ($Path + "GetSmbWitness.XML") }
+            catch { Show-Error("Unable to get SMB Witness state. `nError="+$_.Exception.Message) }
+
+            Show-Update "Clustered Subsystem"
+
+            # NOTE: $Subsystem is reused several times below
+            try {
+                $Subsystem = Get-StorageSubsystem Cluster* -CimSession $AccessNode
+                $Subsystem | Export-Clixml ($Path + "GetStorageSubsystem.XML")
+            }
+            catch { Show-Warning("Unable to get Clustered Subsystem.`nError="+$_.Exception.Message) }
+
+            # Automatic triage is dependent on the cluster (Health Resource), avoid spurious
+            # errors if not available
+            if ($Subsystem.HealthStatus -notlike "Healthy" -and $ClusterName.Length) {
+                Show-Update "Triage for Clustered Subsystem (HealthStatus = $($Subsystem.HealthStatus))"
+                try {
+                    $cmdlet = Get-Command Get-HealthFault -ErrorAction SilentlyContinue
+                    if ($null -ne $cmdlet -and $cmdlet.Source -eq 'FailoverClusters') {
+                        Get-HealthFault  -CimSession $AccessNode |
+                            Export-Clixml (Join-Path $Path "HeathFault.XML")
+                    } else {
+                        $Subsystem | Debug-StorageSubsystem -CimSession $AccessNode |
+                            Export-Clixml (Join-Path $Path "DebugStorageSubsystem.XML")
                     }
                 }
-                catch { $_.Health = "Accessible: "+$_.Exception.Message }
+                catch { Show-Error "Unable to get Get-HealthFault or Debug-StorageSubsystem for unhealthy StorageSubsystem.`nError=" $_ }
             }
-            Write-Progress -Activity "Testing file share access" -Completed
-        }
 
-        $ShareStatus | Export-Clixml ($Path + "ShareStatus.XML")
+            Show-Update "Volumes & Virtual Disks"
 
-        Show-Update "SMB Share Open Files"
+            # Volume status
 
-        try {
-            $o = Get-SmbOpenFile -CimSession $AccessNode
-            $o | Export-Clixml ($Path + "GetSmbOpenFile.XML") }
-        catch { Show-Error("Unable to get SMB open files. `nError="+$_.Exception.Message) }
-
-        Show-Update "SMB Share Witness"
-
-        try {
-            $o = Get-SmbWitnessClient -CimSession $AccessNode
-            $o | Export-Clixml ($Path + "GetSmbWitness.XML") }
-        catch { Show-Error("Unable to get SMB Witness state. `nError="+$_.Exception.Message) }
-
-        Show-Update "Clustered Subsystem"
-
-        # NOTE: $Subsystem is reused several times below
-        try {
-            $Subsystem = Get-StorageSubsystem Cluster* -CimSession $AccessNode
-            $Subsystem | Export-Clixml ($Path + "GetStorageSubsystem.XML")
-        }
-        catch { Show-Warning("Unable to get Clustered Subsystem.`nError="+$_.Exception.Message) }
-
-        # Automatic triage is dependent on the cluster (Health Resource), avoid spurious
-        # errors if not available
-        if ($Subsystem.HealthStatus -notlike "Healthy" -and $ClusterName.Length) {
-            Show-Update "Triage for Clustered Subsystem (HealthStatus = $($Subsystem.HealthStatus))"
             try {
-                $cmdlet = Get-Command Get-HealthFault -ErrorAction SilentlyContinue
-                if ($null -ne $cmdlet -and $cmdlet.Source -eq 'FailoverClusters') {
-                    Get-HealthFault  -CimSession $AccessNode |
-                        Export-Clixml (Join-Path $Path "HeathFault.XML")
-                } else {
-                    $Subsystem | Debug-StorageSubsystem -CimSession $AccessNode |
-                        Export-Clixml (Join-Path $Path "DebugStorageSubsystem.XML")
-                }
+                $Volumes = Get-Volume -CimSession $AccessNode -StorageSubSystem $Subsystem
+                $Volumes | Export-Clixml ($Path + "GetVolume.XML") }
+            catch { Show-Error("Unable to get Volumes. `nError="+$_.Exception.Message) }
+
+            # Virtual disk health
+            # Used in S2D-specific gather below
+
+            try {
+                $VirtualDisk = Get-VirtualDisk -CimSession $AccessNode -StorageSubSystem $Subsystem
+                $VirtualDisk | Export-Clixml ($Path + "GetVirtualDisk.XML")
             }
-            catch { Show-Error "Unable to get Get-HealthFault or Debug-StorageSubsystem for unhealthy StorageSubsystem.`nError=" $_ }
-        }
+            catch { Show-Warning("Unable to get Virtual Disks.`nError="+$_.Exception.Message) }
 
-        Show-Update "Volumes & Virtual Disks"
+            # Deduplicated volume health
+            # XXX the counts/healthy likely not needed once phase 2 shifted into summary report
 
-        # Volume status
+            if ($DedupEnabled)
+            {
+                Show-Update "Dedup Volume Status"
 
-        try {
-            $Volumes = Get-Volume -CimSession $AccessNode -StorageSubSystem $Subsystem
-            $Volumes | Export-Clixml ($Path + "GetVolume.XML") }
-        catch { Show-Error("Unable to get Volumes. `nError="+$_.Exception.Message) }
+                try {
+                    $DedupVolumes = Invoke-Command -ComputerName $AccessNode -ConfigurationName $SessionConfigurationName { Get-DedupStatus }
+                    $DedupVolumes | Export-Clixml ($Path + "GetDedupVolume.XML") }
+                catch { Show-Error("Unable to get Dedup Volumes.`nError="+$_.Exception.Message) }
 
-        # Virtual disk health
-        # Used in S2D-specific gather below
+                $DedupTotal = NCount($DedupVolumes)
+                $DedupHealthy = NCount($DedupVolumes |? LastOptimizationResult -eq 0 )
 
-        try {
-            $VirtualDisk = Get-VirtualDisk -CimSession $AccessNode -StorageSubSystem $Subsystem
-            $VirtualDisk | Export-Clixml ($Path + "GetVirtualDisk.XML")
-        }
-        catch { Show-Warning("Unable to get Virtual Disks.`nError="+$_.Exception.Message) }
+            } else {
 
-        # Deduplicated volume health
-        # XXX the counts/healthy likely not needed once phase 2 shifted into summary report
+                $DedupVolumes = @()
+                $DedupTotal = 0
+                $DedupHealthy = 0
+            }
 
-        if ($DedupEnabled)
-        {
-            Show-Update "Dedup Volume Status"
+            Show-Update "Storage Pool & Tiers"
 
-            try {
-                $DedupVolumes = Invoke-Command -ComputerName $AccessNode -ConfigurationName $SessionConfigurationName { Get-DedupStatus }
-                $DedupVolumes | Export-Clixml ($Path + "GetDedupVolume.XML") }
-            catch { Show-Error("Unable to get Dedup Volumes.`nError="+$_.Exception.Message) }
-
-            $DedupTotal = NCount($DedupVolumes)
-            $DedupHealthy = NCount($DedupVolumes |? LastOptimizationResult -eq 0 )
-
-        } else {
-
-            $DedupVolumes = @()
-            $DedupTotal = 0
-            $DedupHealthy = 0
-        }
-
-        Show-Update "Storage Pool & Tiers"
-
-        # Storage tier information
-
-        try {
-            Get-StorageTier -CimSession $AccessNode |
-                Export-Clixml ($Path + "GetStorageTier.XML") }
-        catch { Show-Warning("Unable to get Storage Tiers. `nError="+$_.Exception.Message) }
-
-        # Storage pool health
-        try {
-            $StoragePools = @(Get-StoragePool -IsPrimordial $False -CimSession $AccessNode -StorageSubSystem $Subsystem -ErrorAction SilentlyContinue)
-            $StoragePools | Export-Clixml ($Path + "GetStoragePool.XML") }
-        catch { Show-Error("Unable to get Storage Pools. `nError="+$_.Exception.Message) }
-
-        Show-Update "Storage Jobs"
-
-        try {
-            # cannot subsystem scope Get-StorageJob at this time
-            icm $AccessNode -ConfigurationName $SessionConfigurationName { Get-StorageJob } |
-                Export-Clixml ($Path + "GetStorageJob.XML") }
-        catch { Show-Warning("Unable to get Storage Jobs. `nError="+$_.Exception.Message) }
-
-        Show-Update "Clustered PhysicalDisks and SNV"
-
-        # Physical disk health
-
-        try {
-            $PhysicalDisks = Get-PhysicalDisk -CimSession $AccessNode -StorageSubSystem $Subsystem
-            $PhysicalDisks | Export-Clixml ($Path + "GetPhysicalDisk.XML") }
-        catch { Show-Error("Unable to get Physical Disks. `nError="+$_.Exception.Message) }
-
-        try {
-            Get-PhysicalDisk -CimSession $AccessNode -StorageSubSystem $Subsystem | Get-PhysicalDiskSNV -CimSession $AccessNode |
-                Export-Clixml ($Path + "GetPhysicalDiskSNV.XML") }
-        catch { Show-Error("Unable to get Physical Disk Storage Node View. `nError="+$_.Exception.Message) }
-
-        # Reliability counters
-        # These may cause a latency burst on some devices due to device-specific requirements for lifting/generating
-        # the SMART data which underlies them. Decline to do this by default.
-
-        if ($IncludeReliabilityCounters -eq $true) {
-
-            Show-Update "Storage Reliability Counters"
+            # Storage tier information
 
             try {
-                $PhysicalDisks | Get-StorageReliabilityCounter -CimSession $AccessNode |
-                    Export-Clixml ($Path + "GetReliabilityCounter.XML") }
-            catch { Show-Error("Unable to get Storage Reliability Counters. `nError="+$_.Exception.Message) }
+                Get-StorageTier -CimSession $AccessNode |
+                    Export-Clixml ($Path + "GetStorageTier.XML") }
+            catch { Show-Warning("Unable to get Storage Tiers. `nError="+$_.Exception.Message) }
 
+            # Storage pool health
+
+            try {
+                $StoragePools = @(Get-StoragePool -IsPrimordial $False -CimSession $AccessNode -StorageSubSystem $Subsystem -ErrorAction SilentlyContinue)
+                $StoragePools | Export-Clixml ($Path + "GetStoragePool.XML") }
+            catch { Show-Error("Unable to get Storage Pools. `nError="+$_.Exception.Message) }
+
+            Show-Update "Storage Jobs"
+
+            try {
+                # cannot subsystem scope Get-StorageJob at this time
+                icm $AccessNode -ConfigurationName $SessionConfigurationName { Get-StorageJob } |
+                    Export-Clixml ($Path + "GetStorageJob.XML") }
+            catch { Show-Warning("Unable to get Storage Jobs. `nError="+$_.Exception.Message) }
+
+            Show-Update "Clustered PhysicalDisks and SNV"
+
+            # Physical disk health
+
+            try {
+                $PhysicalDisks = Get-PhysicalDisk -CimSession $AccessNode -StorageSubSystem $Subsystem
+                $PhysicalDisks | Export-Clixml ($Path + "GetPhysicalDisk.XML") }
+            catch { Show-Error("Unable to get Physical Disks. `nError="+$_.Exception.Message) }
+
+            try {
+                Get-PhysicalDisk -CimSession $AccessNode -StorageSubSystem $Subsystem | Get-PhysicalDiskSNV -CimSession $AccessNode |
+                    Export-Clixml ($Path + "GetPhysicalDiskSNV.XML") }
+            catch { Show-Error("Unable to get Physical Disk Storage Node View. `nError="+$_.Exception.Message) }
+
+            # Reliability counters
+            # These may cause a latency burst on some devices due to device-specific requirements for lifting/generating
+            # the SMART data which underlies them. Decline to do this by default.
+
+            if ($IncludeReliabilityCounters -eq $true) {
+
+                Show-Update "Storage Reliability Counters"
+
+                try {
+                    $PhysicalDisks | Get-StorageReliabilityCounter -CimSession $AccessNode |
+                        Export-Clixml ($Path + "GetReliabilityCounter.XML") }
+                catch { Show-Error("Unable to get Storage Reliability Counters. `nError="+$_.Exception.Message) }
+
+            }
+
+            # Storage enclosure health
+
+            Show-Update "Storage Enclosures"
+
+            try {
+                Get-StorageEnclosure -CimSession $AccessNode -StorageSubSystem $Subsystem |
+                    Export-Clixml ($Path + "GetStorageEnclosure.XML") }
+            catch { Show-Error("Unable to get Enclosures. `nError="+$_.Exception.Message) }
         }
-
-        # Storage enclosure health
-
-        Show-Update "Storage Enclosures"
-
-        try {
-            Get-StorageEnclosure -CimSession $AccessNode -StorageSubSystem $Subsystem |
-                Export-Clixml ($Path + "GetStorageEnclosure.XML") }
-        catch { Show-Error("Unable to get Enclosures. `nError="+$_.Exception.Message) }
 
         # Undo changes as this is failing in AzureStack environment.
         # SDDC cim objects

--- a/PrivateCloud.DiagnosticInfo/PrivateCloud.DiagnosticInfo.psm1
+++ b/PrivateCloud.DiagnosticInfo/PrivateCloud.DiagnosticInfo.psm1
@@ -2204,7 +2204,7 @@ function Get-SddcDiagnosticInfo
             {
                 $null = Get-ClusterLog -Node $using:ClusterNodes.Name -Destination $using:Path -UseLocalTime -Netft
             }
-            if ($S2DEnabled) {
+            if ($using:S2DEnabled) {
                 $null = Get-ClusterLog -Node $using:ClusterNodes.Name -Destination $using:Path -Health -UseLocalTime
             }
         }

--- a/PrivateCloud.DiagnosticInfo/PrivateCloud.DiagnosticInfo.psm1
+++ b/PrivateCloud.DiagnosticInfo/PrivateCloud.DiagnosticInfo.psm1
@@ -1962,23 +1962,8 @@ function Get-SddcDiagnosticInfo
                     Export-Clixml ($using:Path + "GetClusterQuorum.XML")
                 }
                 catch { Show-Warning("Unable to get Cluster Quorum.  `nError="+$_.Exception.Message) }
-            }
-
-            $JobStatic += start-job -Name CauDebugTrace {
-                try {
-
-                    # SCDT returns a fileinfo object for the saved ZIP on the pipeline; discard (allow errors/warnings to flow as normal)
-
-                    if ((Get-Command Save-CauDebugTrace).Parameters.ContainsKey("FeatureUpdateLogs")) {
-                        $null = Save-CauDebugTrace -Cluster $using:AccessNode -FeatureUpdateLogs All -FilePath $using:Path
-                    }
-                    else {
-                        $null = Save-CauDebugTrace -Cluster $using:AccessNode -FilePath $using:Path
-                    }
-                }
-                catch { Show-Warning("Unable to get CAU debug trace.  `nError="+$_.Exception.Message) }
-            }
-
+            } 
+            
         } else {
             Show-Update "... Skip gather of cluster configuration since cluster is not available"
         }
@@ -2196,7 +2181,7 @@ function Get-SddcDiagnosticInfo
         }
 
         # Events, cmd, reports, et.al.
-        Show-Update "Start gather of system info, cluster/netft/health logs, reports and dump files ..."
+        Show-Update "Start gather of system info, cluster/netft/health/CAU logs, reports and dump files ..."
 
         $JobStatic += Start-Job -Name ClusterLogs {
             $null = Get-ClusterLog -Node $using:ClusterNodes.Name -Destination $using:Path -UseLocalTime
@@ -2207,6 +2192,17 @@ function Get-SddcDiagnosticInfo
             if ($using:S2DEnabled) {
                 $null = Get-ClusterLog -Node $using:ClusterNodes.Name -Destination $using:Path -Health -UseLocalTime
             }
+
+            try {
+                    # SCDT returns a fileinfo object for the saved ZIP on the pipeline; discard (allow errors/warnings to flow as normal)
+                    if ((Get-Command Save-CauDebugTrace).Parameters.ContainsKey("FeatureUpdateLogs")) {
+                        $null = Save-CauDebugTrace -Cluster $using:AccessNode -FeatureUpdateLogs All -FilePath $using:Path
+                    }
+                    else {
+                        $null = Save-CauDebugTrace -Cluster $using:AccessNode -FilePath $using:Path
+                    }
+                }
+                catch { Show-Warning("Unable to get CAU debug trace.  `nError="+$_.Exception.Message) }
         }
 
         $JobStatic += $ClusterNodes.Name |% {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Moved the get-cluster logs call to collect the health logs into the same job that is collecting the netft and cluster log. -->

## PR Context

<!-- There is an issue with not all logs being collected (netft, cluster and health) when the log collection happens in parallel. This change combines log collection for the cluster, netft and health logs into one job. Testing this change locally resulted in a significant improvement in the success rate of collecting all the cluster logs.    -->
